### PR TITLE
Spanish translation implemented

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -7,15 +7,16 @@ description 'ESX Optional Needs'
 version '1.0.0'
 
 server_scripts {
-	'@es_extended/locale.lua',
-	'locales/en.lua',
-	'locales/fi.lua',
-	'locales/fr.lua',
-	'locales/pl.lua',
-	'config.lua',
-	'server/main.lua'
+    '@es_extended/locale.lua',
+    'locales/en.lua',
+    'locales/es.lua',
+    'locales/fi.lua',
+    'locales/fr.lua',
+    'locales/pl.lua',
+    'config.lua',
+    'server/main.lua'
 }
 
 client_scripts {
-	'client/main.lua'
+    'client/main.lua'
 }

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -1,0 +1,5 @@
+Locales['es'] = {
+    
+    ['used_beer'] = 'Has usado 1x ~y~Cerveza~s~',
+
+}

--- a/localization/es_esx_optionalneeds.sql
+++ b/localization/es_esx_optionalneeds.sql
@@ -1,0 +1,11 @@
+USE `es_extended`;
+
+INSERT INTO `items` (`name`, `label`, `weight`) VALUES
+	('beer', 'Cerveza', 1)
+;
+
+INSERT INTO `shops` (store, item, price) VALUES
+	('TwentyFourSeven', 'beer', 45),
+	('RobsLiquor', 'beer', 45),
+	('LTDgasoline', 'beer', 45)
+;


### PR DESCRIPTION
Spanish translation implemented in the script.

e7f18cb - Created the sql `es_esx_optionalneeds.sql` with the spanish translation for the database

453fc80 - Added the translations of the script in Spanish and fixed the spacing of fxmanifest.lua (4 spaces per tab)